### PR TITLE
fix: avoid _buildPicture each time when click on the same location

### DIFF
--- a/lib/service/inspector/inspector_overlay.dart
+++ b/lib/service/inspector/inspector_overlay.dart
@@ -78,6 +78,8 @@ class _RenderInspectorOverlay extends RenderBox {
   }
 }
 
+_InspectorOverlayRenderState? _lastState;
+
 class _InspectorOverlayLayer extends Layer {
   _InspectorOverlayLayer({
     required this.overlayRect,
@@ -94,8 +96,6 @@ class _InspectorOverlayLayer extends Layer {
   final bool needEdges;
 
   final Rect overlayRect;
-
-  _InspectorOverlayRenderState? _lastState;
 
   late ui.Picture _picture;
 


### PR DESCRIPTION
[fix] Avoid `_buildPicture` each time when click on the same location, because the `_lastState` is always `null`, so i put it outside.
Related here:
```
if (state != _lastState) {
      _lastState = state;
      _picture = _buildPicture(state);
}
```