### PR TITLE
Inject UME gracefully

### DIFF
--- a/custom_plugin_example/lib/main.dart
+++ b/custom_plugin_example/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter_ume/flutter_ume.dart';
 import 'custom_log.dart';
 
 void main() {
-  runApp(injectUMEWidget(child: MyApp(), enable: true));
+  runApp(UMEWidget(child: MyApp()));
   PluginManager.instance..register(CustomLog());
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,19 +29,17 @@ void main() {
       ..register(DeviceInfoPanel())
       ..register(Console())
       ..register(DioInspector(dio: dio));
-    runApp(MultiProvider(
-      providers: [
-        ChangeNotifierProvider(
-          create: (_) => UMESwitch(),
-        ),
-      ],
-      builder: (ctx, child) {
-        return injectUMEWidget(
-          child: MyApp(),
+    runApp(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => UMESwitch()),
+        ],
+        builder: (ctx, child) => UMEWidget(
           enable: ctx.watch<UMESwitch>().enable,
-        );
-      },
-    ));
+          child: MyApp(),
+        ),
+      ),
+    );
   } else {
     runApp(MyApp());
   }

--- a/lib/core/ui/root_widget.dart
+++ b/lib/core/ui/root_widget.dart
@@ -100,7 +100,7 @@ class _UMEWidgetState extends State<UMEWidget> {
   @override
   void didUpdateWidget(UMEWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.enabled != oldWidget.enabled && widget.enabled) {
+    if (widget.enable != oldWidget.enable && widget.enable) {
       _injectOverlay();
     }
     if (widget.child != oldWidget.child) {

--- a/lib/core/ui/root_widget.dart
+++ b/lib/core/ui/root_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart'
@@ -25,6 +27,10 @@ const defaultLocalizationsDelegates = const [
 final GlobalKey<OverlayState> overlayKey = GlobalKey<OverlayState>();
 
 /// Wrap your App widget. If [enable] is false, the function will return [child].
+@Deprecated(
+  'injectUMEWidget has been deprecated since 0.3.0. '
+  'Use UMEWidget instead.',
+)
 Widget injectUMEWidget({
   required Widget child,
   required bool enable,
@@ -61,6 +67,79 @@ Widget injectUMEWidget({
       ],
     ),
   );
+}
+
+class UMEWidget extends StatefulWidget {
+  const UMEWidget({
+    Key? key,
+    required this.child,
+    this.enable = true,
+    this.supportedLocales,
+    this.localizationsDelegates = defaultLocalizationsDelegates,
+  }) : super(key: key);
+
+  final Widget child;
+  final bool enable;
+  final Iterable<Locale>? supportedLocales;
+  final Iterable<LocalizationsDelegate> localizationsDelegates;
+
+  @override
+  _UMEWidgetState createState() => _UMEWidgetState();
+}
+
+class _UMEWidgetState extends State<UMEWidget> {
+  late Widget _child;
+
+  @override
+  void initState() {
+    super.initState();
+    _replaceChild();
+    _injectOverlay();
+  }
+
+  @override
+  void didUpdateWidget(UMEWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.enable != oldWidget.enable || widget.child != oldWidget.child) {
+      _replaceChild();
+    }
+  }
+
+  void _replaceChild() {
+    _child = RepaintBoundary(key: rootKey, child: widget.child);
+  }
+
+  void _injectOverlay() {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+      if (widget.enable) {
+        final overlayEntry = OverlayEntry(
+          builder: (_) => const _FloatingWidget(),
+        );
+        overlayKey.currentState?.insert(overlayEntry);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.enable) {
+      return _child;
+    }
+    return Stack(
+      textDirection: TextDirection.ltr,
+      children: <Widget>[
+        _child,
+        MediaQuery(
+          data: MediaQueryData.fromWindow(ui.window),
+          child: Localizations(
+            locale: widget.supportedLocales?.first ?? Locale('en', 'US'),
+            delegates: widget.localizationsDelegates.toList(),
+            child: ScaffoldMessenger(child: Overlay(key: overlayKey)),
+          ),
+        )
+      ],
+    );
+  }
 }
 
 class _FloatingWidget extends StatelessWidget {

--- a/lib/core/ui/root_widget.dart
+++ b/lib/core/ui/root_widget.dart
@@ -100,7 +100,10 @@ class _UMEWidgetState extends State<UMEWidget> {
   @override
   void didUpdateWidget(UMEWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.enable != oldWidget.enable || widget.child != oldWidget.child) {
+    if (widget.enabled != oldWidget.enabled && widget.enabled) {
+      _injectOverlay();
+    }
+    if (widget.child != oldWidget.child) {
       _replaceChild();
     }
   }

--- a/test/core/ui/root_widget_test.dart
+++ b/test/core/ui/root_widget_test.dart
@@ -21,12 +21,13 @@ void main() {
 
   group('RootWidget', () {
     testWidgets('RootWidget assert constructor', (tester) async {
-      expect(
-          UMEWidget(
-            child: Container(),
-            enable: false,
-          ),
-          isInstanceOf<Container>());
+      await tester.pumpWidget(UMEWidget(
+        child: Container(),
+        enable: false,
+      ));
+      expect(find.byType(UMEWidget), isOnstage);
+      expect(find.byType(Container), isOnstage);
+      expect(find.byType(Overlay), findsNothing);
     });
 
     testWidgets('RootWidget pump widget', (tester) async {

--- a/test/core/ui/root_widget_test.dart
+++ b/test/core/ui/root_widget_test.dart
@@ -22,7 +22,7 @@ void main() {
   group('RootWidget', () {
     testWidgets('RootWidget assert constructor', (tester) async {
       expect(
-          injectUMEWidget(
+          UMEWidget(
             child: Container(),
             enable: false,
           ),
@@ -32,7 +32,7 @@ void main() {
     testWidgets('RootWidget pump widget', (tester) async {
       PluginManager.instance
           .registerAll([MockPluggable(), MockPluggableWithStream()]);
-      final umeRoot = injectUMEWidget(
+      final umeRoot = UMEWidget(
           child: MaterialApp(
               home: Scaffold(
             body: Container(),
@@ -64,7 +64,7 @@ void main() {
 
       PluginManager.instance
           .registerAll([MockPluggable(), MockPluggableWithStream()]);
-      final umeRoot = injectUMEWidget(
+      final umeRoot = UMEWidget(
           child: MaterialApp(
               home: Scaffold(
             body: Container(),
@@ -80,7 +80,7 @@ void main() {
     testWidgets('RootWidget flutter logo drag', (tester) async {
       PluginManager.instance
           .registerAll([MockPluggable(), MockPluggableWithStream()]);
-      final umeRoot = injectUMEWidget(
+      final umeRoot = UMEWidget(
           child: MaterialApp(
               home: Scaffold(
             body: Container(),
@@ -103,7 +103,7 @@ void main() {
     testWidgets('RootWidget flutter logo drag', (tester) async {
       PluginManager.instance
           .registerAll([MockPluggable(), MockPluggableWithStream()]);
-      final umeRoot = injectUMEWidget(
+      final umeRoot = UMEWidget(
           child: MaterialApp(
               home: Scaffold(
             body: Container(),
@@ -123,7 +123,7 @@ void main() {
     testWidgets('RootWidget flutter logo tap', (tester) async {
       PluginManager.instance
           .registerAll([MockPluggable(), MockPluggableWithStream()]);
-      final umeRoot = injectUMEWidget(
+      final umeRoot = UMEWidget(
           child: MaterialApp(
               home: Scaffold(
             body: Container(),
@@ -150,7 +150,7 @@ void main() {
       PluginManager.instance
           .registerAll([MockPluggable(), MockPluggableWithStream()]);
 
-      final umeRoot = injectUMEWidget(
+      final umeRoot = UMEWidget(
           child: MaterialApp(
               home: Scaffold(
             body: Container(),


### PR DESCRIPTION
- Refactored UME injection with a const widget, which will resolve the reassemble issue. Previously the UME overlay will insert again once the `reassemble()` was called.
- Deprecated `injectUMEWidget` function.
- Separate localizations and directionality to avoid nested context issues when trying to find the `TextDirection` through a `BuildContext`.

## Pull Request Checklist

- [x] I have read the [UME contribution document](../CONTRIBUTING.md) and understand how to contribute, commit the code according to the rules. 我已阅读过 UME 贡献文档，并了解如何进行贡献，按照规则提交了代码
- [x] I have added the necessary comments in code to ensure that other contributors can understand the reason for the change. 我在修改中已经添加了必要的注释，以确保便于其他贡献者理解修改原因
- [x] The code has been formatted by dartfmt before push. 代码在提交前已经经过 dartfmt 进行了格式化
- [x] Change does not involve the adjustment of test cases. Or all existing and new tests are passing. 改动不涉及测试用例调整，或 example 工程与单元测试已经完全跑通