### PR TITLE
fix compile error after Flutter 2.11.0-0.0.pre.818 on widget_detail_inspector.search_bar

### DIFF
--- a/kits/flutter_ume_kit_ui/lib/components/widget_detail_inspector/search_bar.dart
+++ b/kits/flutter_ume_kit_ui/lib/components/widget_detail_inspector/search_bar.dart
@@ -148,8 +148,7 @@ class _SearchInputState extends State<SearchBar> {
         autofocus: widget.autofocus,
         maxLines: 1,
         onSubmitted: _inputSubmitHandle,
-        // ignore: deprecated_member_use
-        maxLengthEnforced: false,
+        maxLengthEnforcement: MaxLengthEnforcement.none,
         style: TextStyle(
           fontSize: 15.0,
           color: Colors.black,


### PR DESCRIPTION
after Flutter 2.11.0-0.0.pre.818, the maxLengthEnforced property of TextField is replaced with maxLengthEnforcement