### PR TITLE
✨ Introduce `UMEWidget.closeActivatedPlugin`

### DIFF
--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:example/ume_switch.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_ume/flutter_ume.dart';
 import 'package:provider/provider.dart';
 
 import 'main.dart';
@@ -33,15 +34,21 @@ class _HomePageState extends State<HomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             TextButton(
-                onPressed: () {
-                  debugPrint('statement');
-                },
-                child: const Text('debugPrint')),
+              onPressed: () => UMEWidget.closeActivatedPlugin(),
+              child: const Text('Close activated plugin'),
+            ),
             TextButton(
-                onPressed: () {
-                  Navigator.of(context).pushNamed('detail');
-                },
-                child: const Text('Push Detail Page')),
+              onPressed: () {
+                debugPrint('statement');
+              },
+              child: const Text('debugPrint'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pushNamed('detail');
+              },
+              child: const Text('Push Detail Page'),
+            ),
             TextButton(
               onPressed: () {
                 showDialog(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,6 @@ import 'package:example/home_page.dart';
 import 'package:example/ume_switch.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_ume/flutter_ume.dart';
 import 'package:flutter_ume_kit_ui/flutter_ume_kit_ui.dart';
 import 'package:flutter_ume_kit_perf/flutter_ume_kit_perf.dart';
@@ -80,8 +79,7 @@ class _MyAppState extends State<MyApp> {
       onGenerateRoute: (settings) {
         switch (settings.name) {
           case 'detail':
-            return MaterialPageRoute(
-                builder: (BuildContext context) => DetailPage());
+            return MaterialPageRoute(builder: (_) => const DetailPage());
           default:
             return null;
         }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,7 @@
 name: example
 description: A new Flutter project.
 version: 1.0.1
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -8,41 +9,35 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cupertino_icons: ^1.0.3
   provider: ^6.0.3
   # For Dio Kit
   dio: ^4.0.0
 
 dependency_overrides:
-  vm_service: ^6.2.0
-  # flutter_ume: 
-  #   path: ../
-  # flutter_ume_kit_ui:
-  #   path: ../kits/flutter_ume_kit_ui
-  # flutter_ume_kit_perf:
-  #   path: ../kits/flutter_ume_kit_perf
-  # flutter_ume_kit_show_code:
-  #   path: ../kits/flutter_ume_kit_show_code
-  # flutter_ume_kit_device:
-  #   path: ../kits/flutter_ume_kit_device
-  # flutter_ume_kit_console:
-  #   path: ../kits/flutter_ume_kit_console
-  # flutter_ume_kit_dio:
-  #   path: ../kits/flutter_ume_kit_dio
+  vm_service: ^9.4.0
+  flutter_ume:
+    path: ../
 
 dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: ^1.16.6
-  flutter_ume: ^1.0.1
-  flutter_ume_kit_ui: ^1.0.0
-  flutter_ume_kit_perf: ^1.0.0
-  flutter_ume_kit_show_code: ^1.0.0
-  flutter_ume_kit_device: ^1.0.0
-  flutter_ume_kit_console: ^1.0.0
-  flutter_ume_kit_dio: ^1.0.0
+  flutter_ume:
+    path: ../
+  flutter_ume_kit_ui:
+    path: ../kits/flutter_ume_kit_ui
+  flutter_ume_kit_perf:
+    path: ../kits/flutter_ume_kit_perf
+  flutter_ume_kit_show_code:
+    path: ../kits/flutter_ume_kit_show_code
+  flutter_ume_kit_device:
+    path: ../kits/flutter_ume_kit_device
+  flutter_ume_kit_console:
+    path: ../kits/flutter_ume_kit_console
+  flutter_ume_kit_dio:
+    path: ../kits/flutter_ume_kit_dio
   flutter_ume_kit_channel_monitor:
     path: ../kits/flutter_ume_kit_channel_monitor
-  
+
 flutter:
   uses-material-design: true

--- a/lib/core/ui/root_widget.dart
+++ b/lib/core/ui/root_widget.dart
@@ -39,15 +39,41 @@ class UMEWidget extends StatefulWidget {
   final Iterable<Locale>? supportedLocales;
   final Iterable<LocalizationsDelegate> localizationsDelegates;
 
+  /// Close the activated plugin if any.
+  ///
+  /// The method does not have side-effects whether the [UMEWidget]
+  /// is not enabled or no plugin has been activated.
+  static void closeActivatedPlugin() {
+    final _ContentPageState? state =
+        _umeWidgetState?._contentPageKey.currentState;
+    if (state?._currentSelected != null) {
+      state?._closeActivatedPluggable();
+    }
+  }
+
   @override
   _UMEWidgetState createState() => _UMEWidgetState();
 }
 
+/// Hold the [_UMEWidgetState] as a global variable.
+_UMEWidgetState? _umeWidgetState;
+
 class _UMEWidgetState extends State<UMEWidget> {
+  _UMEWidgetState() {
+    // Make sure only a single `UMEWidget` is being used.
+    assert(
+      _umeWidgetState == null,
+      'Only one `UMEWidget` can be used at the same time.',
+    );
+    if (_umeWidgetState != null) {
+      throw StateError('Only one `UMEWidget` can be used at the same time.');
+    }
+    _umeWidgetState = this;
+  }
+
+  final GlobalKey<_ContentPageState> _contentPageKey = GlobalKey();
   late Widget _child;
-
   VoidCallback? _onMetricsChanged;
-
   OverlayEntry _overlayEntry = OverlayEntry(builder: (ctx) => Container());
 
   @override
@@ -74,6 +100,8 @@ class _UMEWidgetState extends State<UMEWidget> {
           _onMetricsChanged;
     }
     super.dispose();
+    // Do the cleaning at last.
+    _umeWidgetState = null;
   }
 
   @override
@@ -141,6 +169,7 @@ class _UMEWidgetState extends State<UMEWidget> {
             builder: (_) => Material(
                 type: MaterialType.transparency,
                 child: _ContentPage(
+                  key: _contentPageKey,
                   refreshChildLayout: () {
                     _replaceChild();
                     setState(() {});
@@ -156,15 +185,15 @@ class _UMEWidgetState extends State<UMEWidget> {
 }
 
 class _ContentPage extends StatefulWidget {
-  _ContentPage({Key? key, this.refreshChildLayout}) : super(key: key);
+  const _ContentPage({Key? key, this.refreshChildLayout}) : super(key: key);
 
   final VoidCallback? refreshChildLayout;
 
   @override
-  __ContentPageState createState() => __ContentPageState();
+  _ContentPageState createState() => _ContentPageState();
 }
 
-class __ContentPageState extends State<_ContentPage> {
+class _ContentPageState extends State<_ContentPage> {
   PluginStoreManager _storeManager = PluginStoreManager();
   Size _windowSize = windowSize;
   double _dx = 0;
@@ -204,21 +233,25 @@ class __ContentPageState extends State<_ContentPage> {
 
   void onTap() {
     if (_currentSelected != null) {
-      PluginManager.instance.deactivatePluggable(_currentSelected!);
-      if (widget.refreshChildLayout != null) {
-        widget.refreshChildLayout!();
-      }
-      _currentSelected = null;
-      _currentWidget = _empty;
-      if (_minimalContent) {
-        _currentWidget = _toolbarWidget;
-        _showedMenu = true;
-      }
-      setState(() {});
+      _closeActivatedPluggable();
       return;
     }
     _showedMenu = !_showedMenu;
     _updatePanelWidget();
+  }
+
+  void _closeActivatedPluggable() {
+    PluginManager.instance.deactivatePluggable(_currentSelected!);
+    if (widget.refreshChildLayout != null) {
+      widget.refreshChildLayout!();
+    }
+    _currentSelected = null;
+    _currentWidget = _empty;
+    if (_minimalContent) {
+      _currentWidget = _toolbarWidget;
+      _showedMenu = true;
+    }
+    setState(() {});
   }
 
   void _updatePanelWidget() {

--- a/lib/core/ui/root_widget.dart
+++ b/lib/core/ui/root_widget.dart
@@ -179,6 +179,7 @@ class _UMEWidgetState extends State<UMEWidget> {
           builder: (_) => Material(
             type: MaterialType.transparency,
             child: _ContentPage(
+              key: _contentPageKey,
               refreshChildLayout: () {
                 _replaceChild();
                 setState(() {});

--- a/lib/core/ui/root_widget.dart
+++ b/lib/core/ui/root_widget.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart'
     hide FlutterLogo, FlutterLogoDecoration, FlutterLogoStyle;
 import 'package:flutter_ume/core/pluggable_message_service.dart';
@@ -18,7 +17,6 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 const defaultLocalizationsDelegates = const [
   GlobalMaterialLocalizations.delegate,
   GlobalWidgetsLocalizations.delegate,
-  DefaultCupertinoLocalizations.delegate,
   GlobalCupertinoLocalizations.delegate,
 ];
 


### PR DESCRIPTION
Fix #35.

The reason why the method is under the `UMEWidget` is the activated plugin is only related to widget states, not a plugin manager's scope.

## Pull Request Checklist

- [x] I have read the [UME contribution document](../CONTRIBUTING.md) and understand how to contribute, commit the code according to the rules. 我已阅读过 UME 贡献文档，并了解如何进行贡献，按照规则提交了代码
- [x] I have added the necessary comments in code to ensure that other contributors can understand the reason for the change. 我在修改中已经添加了必要的注释，以确保便于其他贡献者理解修改原因
- [x] The code has been formatted by dartfmt before push. 代码在提交前已经经过 dartfmt 进行了格式化
- [ ] Change does not involve the adjustment of test cases. Or all existing and new tests are passing. 改动不涉及测试用例调整，或 example 工程与单元测试已经完全跑通
