### PR TITLE
[Issue #120] fix conflict between the naming of material.SearchBar and ume's SearchBar.

### DIFF
--- a/kits/flutter_ume_kit_ui/lib/components/widget_detail_inspector/widget_detail_inspector.dart
+++ b/kits/flutter_ume_kit_ui/lib/components/widget_detail_inspector/widget_detail_inspector.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_ume_kit_ui/components/hit_test.dart';
 import 'package:flutter_ume/flutter_ume.dart';
 import 'package:flutter_ume_kit_ui/util/binding_ambiguate.dart';
-import 'search_bar.dart';
+import 'search_bar.dart' as search_bar;
 import 'icon.dart' as icon;
 
 class WidgetDetailInspector extends StatelessWidget implements Pluggable {
@@ -199,7 +199,7 @@ class __InfoPageState extends State<_InfoPage> {
               Padding(
                 padding: const EdgeInsets.only(
                     left: 12, right: 12, top: 10, bottom: 10),
-                child: SearchBar(
+                child: search_bar.SearchBar(
                     placeHolder: '请输入要搜索的widget', onChangeHandle: _textChange),
               ),
               Expanded(

--- a/kits/flutter_ume_kit_ui/lib/components/widget_detail_inspector/widget_detail_inspector.dart
+++ b/kits/flutter_ume_kit_ui/lib/components/widget_detail_inspector/widget_detail_inspector.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_ume_kit_ui/components/hit_test.dart';
 import 'package:flutter_ume/flutter_ume.dart';
 import 'package:flutter_ume_kit_ui/util/binding_ambiguate.dart';
+
+// There was a conflict between the naming of material.SearchBar and ume's SearchBar.
 import 'search_bar.dart' as search_bar;
 import 'icon.dart' as icon;
 


### PR DESCRIPTION
Issue: #120 

There was a conflict between the naming of material.SearchBar and ume's SearchBar.
https://api.flutter.dev/flutter/material/SearchBar-class.html

## Pull Request Checklist

- [x] I have read the [UME contribution document](../CONTRIBUTING.md) and understand how to contribute, commit the code according to the rules. 我已阅读过 UME 贡献文档，并了解如何进行贡献，按照规则提交了代码
- [x] I have added the necessary comments in code to ensure that other contributors can understand the reason for the change. 我在修改中已经添加了必要的注释，以确保便于其他贡献者理解修改原因
- [x] The code has been formatted by dartfmt before push. 代码在提交前已经经过 dartfmt 进行了格式化
- [x] Change does not involve the adjustment of test cases. Or all existing and new tests are passing. 改动不涉及测试用例调整，或 example 工程与单元测试已经完全跑通

If you need help, consider [Join ing the ByteDance Flutter Exchange Group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=67au2f75-3783-41b0-8868-0fc0178f1fd8).

如有任何问题，可以[加入字节跳动 Flutter 交流群](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=67au2f75-3783-41b0-8868-0fc0178f1fd8)。

Or contact [author](mailto:sunkai.dev@bytedance.com).

或随时[联系开发者](mailto:sunkai.dev@bytedance.com)。
