### PR TITLE
Add share feature for dio request/response

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,205 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "flutter_ume",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "flutter_ume (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "flutter_ume (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "custom_plugin_example",
+            "cwd": "custom_plugin_example",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "custom_plugin_example (profile mode)",
+            "cwd": "custom_plugin_example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "custom_plugin_example (release mode)",
+            "cwd": "custom_plugin_example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "example",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "example (profile mode)",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "example (release mode)",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "flutter_ume_kit_channel_monitor",
+            "cwd": "kits/flutter_ume_kit_channel_monitor",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "flutter_ume_kit_channel_monitor (profile mode)",
+            "cwd": "kits/flutter_ume_kit_channel_monitor",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "flutter_ume_kit_channel_monitor (release mode)",
+            "cwd": "kits/flutter_ume_kit_channel_monitor",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "flutter_ume_kit_console",
+            "cwd": "kits/flutter_ume_kit_console",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "flutter_ume_kit_console (profile mode)",
+            "cwd": "kits/flutter_ume_kit_console",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "flutter_ume_kit_console (release mode)",
+            "cwd": "kits/flutter_ume_kit_console",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "flutter_ume_kit_device",
+            "cwd": "kits/flutter_ume_kit_device",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "flutter_ume_kit_device (profile mode)",
+            "cwd": "kits/flutter_ume_kit_device",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "flutter_ume_kit_device (release mode)",
+            "cwd": "kits/flutter_ume_kit_device",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "flutter_ume_kit_dio",
+            "cwd": "kits/flutter_ume_kit_dio",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "flutter_ume_kit_dio (profile mode)",
+            "cwd": "kits/flutter_ume_kit_dio",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "flutter_ume_kit_dio (release mode)",
+            "cwd": "kits/flutter_ume_kit_dio",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "flutter_ume_kit_perf",
+            "cwd": "kits/flutter_ume_kit_perf",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "flutter_ume_kit_perf (profile mode)",
+            "cwd": "kits/flutter_ume_kit_perf",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "flutter_ume_kit_perf (release mode)",
+            "cwd": "kits/flutter_ume_kit_perf",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "flutter_ume_kit_show_code",
+            "cwd": "kits/flutter_ume_kit_show_code",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "flutter_ume_kit_show_code (profile mode)",
+            "cwd": "kits/flutter_ume_kit_show_code",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "flutter_ume_kit_show_code (release mode)",
+            "cwd": "kits/flutter_ume_kit_show_code",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "flutter_ume_kit_ui",
+            "cwd": "kits/flutter_ume_kit_ui",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "flutter_ume_kit_ui (profile mode)",
+            "cwd": "kits/flutter_ume_kit_ui",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "flutter_ume_kit_ui (release mode)",
+            "cwd": "kits/flutter_ume_kit_ui",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -75,7 +75,7 @@ class _HomePageState extends State<HomePage> {
                     (int i) => Future<void>.delayed(
                       Duration(seconds: i),
                       () => dio.get(
-                        'https://api.github.com'
+                        'https://apis.github.com'
                         '/?_t=${DateTime.now().millisecondsSinceEpoch}&$i',
                         options: Options(
                           headers: {'UME-Test': 'This is UME Dio kit.'},

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,16 +6,17 @@ import 'package:example/ume_switch.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_ume/flutter_ume.dart';
-import 'package:flutter_ume_kit_ui/flutter_ume_kit_ui.dart';
+import 'package:flutter_ume_kit_channel_monitor/flutter_ume_kit_channel_monitor.dart';
+import 'package:flutter_ume_kit_console/flutter_ume_kit_console.dart';
+import 'package:flutter_ume_kit_device/flutter_ume_kit_device.dart';
+import 'package:flutter_ume_kit_dio/flutter_ume_kit_dio.dart';
 import 'package:flutter_ume_kit_perf/flutter_ume_kit_perf.dart';
 import 'package:flutter_ume_kit_show_code/flutter_ume_kit_show_code.dart';
-import 'package:flutter_ume_kit_device/flutter_ume_kit_device.dart';
-import 'package:flutter_ume_kit_console/flutter_ume_kit_console.dart';
+import 'package:flutter_ume_kit_ui/flutter_ume_kit_ui.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_ume_kit_dio/flutter_ume_kit_dio.dart';
-import 'package:flutter_ume_kit_channel_monitor/flutter_ume_kit_channel_monitor.dart';
 
-final Dio dio = Dio()..options = BaseOptions(connectTimeout: 10000);
+final Dio dio = Dio()
+  ..options = BaseOptions(connectTimeout: Duration(milliseconds: 10000));
 
 final navigatorKey = GlobalKey<NavigatorState>();
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   provider: ^6.0.3
   # For Dio Kit
-  dio: ^4.0.0
+  dio: ^5.1.2
 
 dependency_overrides:
   vm_service: ^9.4.0

--- a/kits/flutter_ume_kit_dio/lib/src/models/http_interceptor.dart
+++ b/kits/flutter_ume_kit_dio/lib/src/models/http_interceptor.dart
@@ -36,8 +36,9 @@ class UMEDioInterceptor extends Interceptor {
   @override
   void onError(DioError err, ErrorInterceptorHandler handler) {
     // Create an empty response with the [RequestOptions] for delivery.
-    err.response ??= Response<dynamic>(requestOptions: err.requestOptions);
-    err.response!.requestOptions.extra[DIO_EXTRA_END_TIME] = _timestamp;
+    var errRespon = Response<dynamic>(requestOptions: err.requestOptions);
+    // err.response ??= Response<dynamic>(requestOptions: err.requestOptions);
+    errRespon.requestOptions.extra[DIO_EXTRA_END_TIME] = _timestamp;
     InspectorInstance.httpContainer.addRequest(err.response!);
     handler.next(err);
   }

--- a/kits/flutter_ume_kit_dio/lib/src/widgets/pluggable_state.dart
+++ b/kits/flutter_ume_kit_dio/lib/src/widgets/pluggable_state.dart
@@ -4,8 +4,9 @@
 ///
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../constants/extensions.dart';
 import '../instances.dart';
@@ -18,13 +19,13 @@ ButtonStyle _buttonStyle(
   EdgeInsetsGeometry? padding,
 }) {
   return TextButton.styleFrom(
+    foregroundColor: Colors.white,
     padding: padding ?? const EdgeInsets.symmetric(horizontal: 5, vertical: 3),
     minimumSize: Size.zero,
     shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.circular(999999),
     ),
     backgroundColor: Theme.of(context).primaryColor,
-    primary: Colors.white,
     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
   );
 }
@@ -116,7 +117,7 @@ class DioPluggableState extends State<DioInspector> {
     return Material(
       color: Colors.black26,
       child: DefaultTextStyle.merge(
-        style: Theme.of(context).textTheme.bodyText2,
+        style: Theme.of(context).textTheme.bodyMedium,
         child: Align(
           alignment: Alignment.bottomCenter,
           child: Container(
@@ -139,7 +140,7 @@ class DioPluggableState extends State<DioInspector> {
                       const Spacer(),
                       Text(
                         'Dio Requests',
-                        style: Theme.of(context).textTheme.subtitle1,
+                        style: Theme.of(context).textTheme.titleMedium,
                       ),
                       Expanded(
                         child: Align(
@@ -308,9 +309,40 @@ class _ResponseCardState extends State<_ResponseCard> {
         const SizedBox(width: 6),
         Text('${_duration.inMilliseconds}ms'),
         const Spacer(),
+        _shareButton(context),
+        const SizedBox(width: 6),
         _detailButton(context),
       ],
     );
+  }
+
+  Widget _shareButton(BuildContext context) {
+    return TextButton(
+      onPressed: () {
+        Share.share(_buildShareContent());
+      },
+      style: _buttonStyle(context),
+      child: const Text(
+        'Share↗',
+        style: TextStyle(fontSize: 12, height: 1.2),
+      ),
+    );
+  }
+
+  _buildShareContent() {
+    return "URL: $_requestUri\n" +
+        "**************\n" +
+        "Request headers\n" +
+        "$_requestHeadersBuilder\n" +
+        "**************\n" +
+        "Request Data\n" +
+        "$_requestDataBuilder\n" +
+        "**************\n" +
+        "Response body\n" +
+        "$_responseDataBuilder\n" +
+        "**************\n" +
+        "Response headers\n" +
+        "$_responseHeadersBuilder\n";
   }
 
   Widget _detailedContent(BuildContext context) {

--- a/kits/flutter_ume_kit_dio/pubspec.yaml
+++ b/kits/flutter_ume_kit_dio/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
 
   dio: ^4.0.0
 
+  share_plus: ^4.5.3
+
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/kits/flutter_ume_kit_dio/pubspec.yaml
+++ b/kits/flutter_ume_kit_dio/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_ume: ">=1.0.0 <2.0.0"
 
-  dio: ^4.0.0
+  dio: ^5.1.2
 
   share_plus: ^4.5.3
 


### PR DESCRIPTION
Now, UME support shares the API request/response to third-party sharable applications. This will reduce the manual task of selecting the text and copy/paste to other applications.

## Pull Request Checklist

- [x] I have read the [UME contribution document](../CONTRIBUTING.md) and understand how to contribute, commit the code according to the rules. 我已阅读过 UME 贡献文档，并了解如何进行贡献，按照规则提交了代码
- [x] I have added the necessary comments in code to ensure that other contributors can understand the reason for the change. 我在修改中已经添加了必要的注释，以确保便于其他贡献者理解修改原因
- [x] The code has been formatted by dartfmt before push. 代码在提交前已经经过 dartfmt 进行了格式化
- [x] Change does not involve the adjustment of test cases. Or all existing and new tests are passing. 改动不涉及测试用例调整，或 example 工程与单元测试已经完全跑通

If you need help, consider [Join ing the ByteDance Flutter Exchange Group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=67au2f75-3783-41b0-8868-0fc0178f1fd8).

如有任何问题，可以[加入字节跳动 Flutter 交流群](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=67au2f75-3783-41b0-8868-0fc0178f1fd8)。

Or contact [author](mailto:sunkai.dev@bytedance.com).

或随时[联系开发者](mailto:sunkai.dev@bytedance.com)。
